### PR TITLE
Create core_guidelines.md

### DIFF
--- a/admin/core_guidelines.md
+++ b/admin/core_guidelines.md
@@ -1,0 +1,21 @@
+## Guia para o core team
+
+Nesse documento constam algumas "regras" e dicas para nossa conduta como `core team` do Training Center.
+
+## Nosso papel
+
+- Somos a moderação da comunidade no geral
+- Devemos ajudar os grupos e pessoas que cuidam de projetos a "cumprirem seus objetivos"
+- Devemos dominar as informações do Training Center para podermos orientar as pessoas
+- Devemos anunciar as coisas que acontecem na nossa comunidade
+- Devemos apoiar o `staff team` quando precisarem
+
+## Regras a seguir
+
+- O uso de `@channel` e `@here` só é permitido quando para anúncios de sorteios, coisas que as pessoas precisam olhar com urgência para poder participar.
+- Quando tivermos algum anúncio a fazer que afete toda a comunidade ou que outras pessoas externas a nós possam querer participar, devemos usar as redes sociais e Medium para tal.
+- Devemos usar issues do GitHub neste repositório quando tivermos que tomar decisões que possamos incluir a comunidade, pois a comunidade deve participar do direcionamento do nosso grupo.
+- Devemos evitar "broncas" em público, mas orientar as pessoas no privado
+- Devemos alertar o `core` quando encontrarmos infrações ao [código de conduta](http://bit.ly/tc-codigo-de-conduta)
+- Devemos comentar pedindo permissão do `core` publicamente quando formos expulsar uma pessoa (por mais que já tenhamos decidido isso no canal do `core`, devemos deixar público que a decisão foi em conjunto)
+- O código de conduta se aplica a todas as pessoas, por isso não favoreça alguém por ser do `core team`


### PR DESCRIPTION
Adicionando documento para auxílio e registro de como o `core team` funciona.