### PR TITLE
Fix broken links to Admins Guide

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -48,7 +48,7 @@ O desrespeito às regras desta comunidade, descritas nesse documento, acarretar�
 
 ## Moderação
 
-Leia o documento sobre a moderação ([Admins Guide](admin/ADMINS_GUIDE.md)) para entender o que fazemos nesta posição e como entrar em contato conosco.
+Leia o documento sobre a moderação ([Admins Guide](admin/docs/ADMINS_GUIDE.md)) para entender o que fazemos nesta posição e como entrar em contato conosco.
 
 Caso você sofra qualquer agressão ou perceba que alguém infringiu nosso código de conduta você pode alertar a moderação ou nos alertar através [deste formulário anônimo](https://trainingcenter2.typeform.com/to/P09LMl). - Tente escrever diferente do que escreve no Slack para que sua identidade continue anônima, pois não é interessante que ninguém saiba que foi você quem fez uma denúncia se ela veio anônima, nem mesmo a moderação.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Você pode fazer uma denúncia anônima através deste formulário: [Central de 
 
 ### Responsabilidades da moderação e liderança
 
-Você pode conferir nossas responsabilidades neste documento: [Admins Guide](/admin/ADMINS_GUIDE.md).
+Você pode conferir nossas responsabilidades neste documento: [Admins Guide](/admin/docs/ADMINS_GUIDE.md).
 
 ## Conhecendo mais sobre nossa comunidade
 


### PR DESCRIPTION
O arquivo foi renomeado em https://github.com/training-center/sobre/commit/b2a73e6c5bb905645b7eca159f66b5ffa6a9790c.
